### PR TITLE
Fix broken link to GitHub issue in opportunity view

### DIFF
--- a/modules/opportunities/client/views/view-opportunity.client.view.html
+++ b/modules/opportunities/client/views/view-opportunity.client.view.html
@@ -116,7 +116,7 @@
 			<!-- github link -->
 			<dt translate="OPP_CODE">Code:</dt>
 			<dd>
-			<a ng-if="vm.opportunity.issueUrl && vm.opportunity.issueUrl.length > 0"><a href="{{vm.opportunity.github}}" rel="nofollow" target="_blank"><i class="fa fa-github"></i> GitHub Repository</a>
+			<a ng-if="vm.opportunity.github && vm.opportunity.github.length > 0"><a href="{{vm.opportunity.github}}" rel="nofollow" target="_blank"><i class="fa fa-github"></i> GitHub Repository</a>
 			<!--<dt>Assigned to:</dt>
 			<dd>
 				<span ng-if="vm.opportunity.assignedTo" ng-bind="vm.opportunity.assignedTo.displayName"></span>
@@ -156,7 +156,7 @@
 			<div class="text-center">
 				<div class="well well-info">
 					<h3 style="margin-top: 0px"><i class="fa fa-comments"></i>&nbsp; Questions?</h3>
-					<p><a href="{{vm.opportunity.issueUrl}}" rel="nofollow" target="_blank" translate="OPP_GITHUB_LINK">Visit the GitHub issue for this opportunity and post a comment.</a></p>
+					<p><a href="{{vm.opportunity.github}}" rel="nofollow" target="_blank" translate="OPP_GITHUB_LINK">Visit the GitHub issue for this opportunity and post a comment.</a></p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Props on posting [your first opportunity](https://beta.gcdevexchange.org/en/opportunities/opp-create-accessible-copies-of-reports-and-summary-tables----cr-er-des-copies-accessibles-des-rapports-et-des-tableaux-sommaires)! I was excited to check it out but had some questions. When I went to click on the link “Visit the GitHub issue for this opportunity and post a comment.” it didn’t work, so I checked the (awesomely open source) code, and saw that the view was referring to a different variable name. I switched it from `vm.opportunity.issueUrl` to `vm.opportunity.github`, which should generate the right URL.

Wasn’t sure which branch to target this to, that might be worth clarifying in the contribution guidelines.